### PR TITLE
Add function options to export()

### DIFF
--- a/dbf/__init__.py
+++ b/dbf/__init__.py
@@ -8713,12 +8713,14 @@ def ensure_unicode(value):
         value = value.decode(input_decoding)
     return value
 
-def export(table_or_records, filename=None, field_names=None, format='csv', header=True, dialect='dbf', encoding=None):
+def export(table_or_records, filename=None, field_names=None, format='csv', header=True, dialect='dbf', encoding=None, ignore_errors=False, ignore_null_bytes=False):
     """
     writes the records using CSV or tab-delimited format, using the filename
     given if specified, otherwise the table name
     if table_or_records is a collection of records (not an actual table) they
     should all be of the same format
+    ignore_errors will skip rows which raise an exception and continue with the export
+    ignore_null_bytes removes all null bytes from output \x00
     """
     table = source_table(table_or_records[0])
     if filename is None:
@@ -8733,9 +8735,15 @@ def export(table_or_records, filename=None, field_names=None, format='csv', head
     if format == 'fixed':
         format = 'txt'
     if encoding is None:
-        encoding = table._meta.codepage
+        encoding = table.codepage.name
     encoder = codecs.getencoder(encoding)
     header_names = field_names
+    #     encoding = table.codepage.name
+    # encoder = codecs.getencoder(encoding)
+    if isinstance(field_names[0], unicode):
+        header_names = [encoder(f) for f in field_names]
+    else:
+        header_names = field_names
     base, ext = os.path.splitext(filename)
     if ext.lower() in ('', '.dbf'):
         filename = base + "." + format
@@ -8745,20 +8753,37 @@ def export(table_or_records, filename=None, field_names=None, format='csv', head
             if header:
                 csvfile.writerow(header_names)
             for record in table_or_records:
-                fields = []
-                for fieldname in field_names:
-                    data = record[fieldname]
-                    fields.append(unicode(data))
-                csvfile.writerow(fields)
+                try:
+                    fields = []
+                    for fieldname in field_names:
+                        data = record[fieldname]
+                        if ignore_null_bytes:
+                            if '\x00' in data:
+                                data = data.replace('\x00', '')
+                        fields.append(unicode(data))
+                    csvfile.writerow(fields)
+                except Exception as e:
+                    if not ignore_errors:
+                        raise e
+                    continue
         elif format == 'tab':
             if header:
                 fd.write('\t'.join(header_names) + '\n')
             for record in table_or_records:
-                fields = []
-                for fieldname in field_names:
-                    data = record[fieldname]
-                    fields.append(unicode(data))
-                fd.write('\t'.join(fields) + '\n')
+                try:
+                    fields = []
+                    for fieldname in field_names:
+                        data = record[fieldname]
+                        if ignore_null_bytes:
+                                if '\x00' in data:
+                                    data = data.replace('\x00', '')
+                        fields.append(unicode(data))
+                    
+                    fd.write('\t'.join(fields) + '\n')
+                except Exception as e:
+                    if not ignore_errors:
+                        raise e
+                continue
         else: # format == 'fixed'
             with codecs.open("%s_layout.txt" % os.path.splitext(filename)[0], 'w', encoding=encoding) as header:
                 header.write("%-15s  Size\n" % "Field Name")
@@ -8770,11 +8795,19 @@ def export(table_or_records, filename=None, field_names=None, format='csv', head
                     header.write("%-15s  %3d\n" % (field, size))
                 header.write('\nTotal Records in file: %d\n' % len(table_or_records))
             for record in table_or_records:
-                fields = []
-                for i, fieldname in enumerate(field_names):
-                    data = record[fieldname]
-                    fields.append("%-*s" % (sizes[i], data))
-                fd.write(''.join(fields) + '\n')
+                try:
+                    fields = []
+                    for i, fieldname in enumerate(field_names):
+                        data = record[fieldname]
+                        if ignore_null_bytes:
+                                if '\x00' in data:
+                                    data = data.replace('\x00', '')
+                        fields.append("%-*s" % (sizes[i], data))
+                    fd.write(''.join(fields) + '\n')
+                except Exception as e:
+                    if not ignore_errors:
+                        raise e
+                    continue
     return len(table_or_records)
 
 def field_names(thing):


### PR DESCRIPTION
When iterating over data to export a table to csv, it is possible that a single row can throw an exception and prevent final export. Added the option to skip rows that cause this.

Null bytes can cause errors on database import if using /COPY from the csv to database. Option to check rows of data for null bytes and remove if found.

ignore_errors: Try/Catch blocks per row of DBF table. In the case a row causes an error and cannot be export, this option allows you to skip the line and continue exporting
ignore_null_bytes: Option to check for and remove null bytes if found in a row of data